### PR TITLE
add register tables for apsystems

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Marcos Caputo (caputomarcos)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Node Red Modbus Client for Solar Edge solar panels.
 
 # How to install?
 
-`npm -i node-red-contrib-solaredge-modbus`
+`npm -i node-red-contrib-solaredge-modbus-client`
 

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Node Red Modbus Client for Solar Edge solar panels.
 
 # How to install?
 
-`npm -i node-red-contrib-solaredge-modbus-client`
+`npm -i node-red-contrib-solaredge-modbus`
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # What is this?
 
-NodeRed node to read SolarEdge Inverter data via the Modbus interface.
+Node Red Modbus Client for Solar Edge solar panels.
 
 # How to install?
 
-'npm -i node-red-contrib-solaredge-modbus-client'
+`npm -i node-red-contrib-solaredge-modbus-client`
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
-# What is this?
+## What is this?
 
-Node Red Modbus Client for Solar Edge solar panels.
+Node Red Modbus Client for SolarEdge inverters.
 
-# How to install?
+## How to install?
+  You can install it using npm:  
+  
+  ```bash
+  $ cd ~/.node-red
+  $ npm install node-red-contrib-solaredge-modbus-client
+  ```
+  Configuration
+  -------------
+  You need the IP address of your SolarEdge inverter and the port number configured for modbus.
 
-`npm -i node-red-contrib-solaredge-modbus-client`
-
+  Output
+  -------
+  The payload will be a json containing the inverter data.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# What is this?
+
+NodeRed node to read SolarEdge Inverter data via the Modbus interface.
+
+# How to install?
+
+'npm -i node-red-contrib-solaredge-modbus-client'
+

--- a/package.json
+++ b/package.json
@@ -26,12 +26,8 @@
     "version": ">=0.1.0",
     "nodes": {
         "se-modbus": "se-modbus-json.js"
-//  "node-red": {
-//    "version": ">=0.1.0",
-//    "nodes": {
-//      "solaredge": "se-modbus-json.js"
-//    }
-//  },
+    }
+  },
   "dependencies": {
     "modbus-tcp": "^0.4.13"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-solaredge-modbus-client",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Node Red Modbus Client for Solar Edge solar panels",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-solaredge-modbus",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Node Red Modbus Client for Solar Edge solar panels",
   "main": "index.js",
   "scripts": {
@@ -9,6 +9,9 @@
   "keywords": [
     "node-red"
   ],
+  "node-red"     : {
+    "nodes": {
+        "se-modbus": "se-modbus-json.js"
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apelders/node-red-solaredge-modbus-client.git"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Xumpy/node-red-solaredge-modbus-client.git"
+    "url": "git+https://github.com/apelders/node-red-solaredge-modbus-client.git"
   },
   "author": "Nico Martens",
   "node-red": {
@@ -24,8 +24,8 @@
   },
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/Xumpy/node-red-solaredge-modbus-client/issues"
+    "url": "https://github.com/apelders/node-red-solaredge-modbus-client/issues"
   },
-  "homepage": "https://github.com/Xumpy/node-red-solaredge-modbus-client#readme",
+  "homepage": "https://github.com/apelders/node-red-solaredge-modbus-client#readme",
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-solaredge-modbus",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Node Red Modbus Client for Solar Edge solar panels",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-solaredge-modbus-client",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Node Red Modbus Client for SolarEdge inverters",
   "author": "Adri Pelders",
   "contributors": [],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-red-contrib-solaredge-modbus-client",
   "version": "1.0.3",
-  "description": "Node Red Modbus Client for SolarEdge solar panels",
+  "description": "Node Red Modbus Client for SolarEdge inverters",
   "author": "Adri Pelders",
   "contributors": [],
   "license": "MIT License",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "node-red-contrib-solaredge-modbus-client",
-  "version": "1.0.3",
+  "name": "node-red-contrib-solaredge-modbus",
+  "version": "1.0.0",
   "description": "Node Red Modbus Client for Solar Edge solar panels",
   "main": "index.js",
   "scripts": {
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/apelders/node-red-solaredge-modbus-client.git"
   },
-  "author": "Nico Martens",
+  "author": "Adri Pelders",
   "node-red": {
     "nodes": {
       "solaredge": "se-modbus-json.js"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "keywords": [
     "node-red",
-    "SolarEdge""
+    "SolarEdge"
   ],
   "node-red"     : {
     "version": ">=0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,34 +1,39 @@
 {
-  "name": "node-red-contrib-solaredge-modbus",
-  "version": "1.0.2",
-  "description": "Node Red Modbus Client for Solar Edge solar panels",
+  "name": "node-red-contrib-solaredge-modbus-client",
+  "version": "1.0.3",
+  "description": "Node Red Modbus Client for SolarEdge solar panels",
+  "author": "Adri Pelders",
+  "contributors": [],
+  "license": "MIT License",
+  "homepage": "https://github.com/apelders/node-red-contrib-solaredge-modbus-client/#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apelders/node-red-solaredge-modbus-client.git"
+  },
+  "bugs": {
+    "url": "https://github.com/apelders/node-red-solaredge-modbus-client/issues"
+  },
+  "private": "true",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
-    "node-red"
+    "node-red",
+    "SolarEdge""
   ],
   "node-red"     : {
+    "version": ">=0.1.0",
     "nodes": {
         "se-modbus": "se-modbus-json.js"
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/apelders/node-red-solaredge-modbus-client.git"
-  },
-  "author": "Adri Pelders",
-  "node-red": {
-    "nodes": {
-      "solaredge": "se-modbus-json.js"
-    }
-  },
+//  "node-red": {
+//    "version": ">=0.1.0",
+//    "nodes": {
+//      "solaredge": "se-modbus-json.js"
+//    }
+//  },
   "dependencies": {
     "modbus-tcp": "^0.4.13"
   },
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/apelders/node-red-solaredge-modbus-client/issues"
-  },
-  "homepage": "https://github.com/apelders/node-red-solaredge-modbus-client#readme",
   "devDependencies": {}
 }

--- a/se-modbus-json.html
+++ b/se-modbus-json.html
@@ -4,7 +4,7 @@
         color: '#fff665',
         defaults: {
 			name: {value:"Solar Edge Modbus"},
-            host: {value:"192.168.1.200"},
+            host: {value:"192.168.1.70"},
 			port: {value:"1502"},
             poll: {value:"1000"},
             device: {value: "se_inverter"}


### PR DESCRIPTION
I tried this node with the Apsystems ECU -C interface.
Getting data is OK register are displaced for Apsystems.
 I modified your node for making it universal.
Sunspec Mode v101 is ok  Mode v111 and v123 needs a further update.
[Sunspec Modbus.zip](https://github.com/Xumpy/node-red-solaredge-modbus-client/files/7030299/Sunspec.Modbus.zip)

[https://certifications.sunspec.org/PICS/Altenergy_Power_System_Inc.___single_phase_MicroinverterAPpcs_11-12.xlsx](url)
[config_json.zip](https://github.com/Xumpy/node-red-solaredge-modbus-client/files/7026772

